### PR TITLE
Replace deprecated device entry_type string

### DIFF
--- a/custom_components/netdaemon/entity.py
+++ b/custom_components/netdaemon/entity.py
@@ -1,6 +1,7 @@
 """NetDaemon entity."""
+from awesomeversion import AwesomeVersion
+from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -57,13 +58,21 @@ class NetDaemonEntity(CoordinatorEntity):
     @property
     def device_info(self):
         """Return device information about NetDaemon."""
-        return {
+        info = {
             "identifiers": {(DOMAIN, ND_ID)},
             "name": NAME,
             "sw_version": INTEGRATION_VERSION,
             "manufacturer": "netdaemon.xyz",
-            "entry_type": DeviceEntryType.SERVICE,
         }
+        # LEGACY can be removed when min HA version is 2021.12
+        if AwesomeVersion(HA_VERSION) >= "2021.12.0b0":
+            # pylint: disable=import-outside-toplevel
+            from homeassistant.helpers.device_registry import DeviceEntryType
+
+            info["entry_type"] = DeviceEntryType.SERVICE
+        else:
+            info["entry_type"] = "service"
+        return info
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/netdaemon/entity.py
+++ b/custom_components/netdaemon/entity.py
@@ -1,5 +1,6 @@
 """NetDaemon entity."""
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -61,7 +62,7 @@ class NetDaemonEntity(CoordinatorEntity):
             "name": NAME,
             "sw_version": INTEGRATION_VERSION,
             "manufacturer": "netdaemon.xyz",
-            "entry_type": "service",
+            "entry_type": DeviceEntryType.SERVICE,
         }
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Use DeviceEntryType.SERVICE, "service" string for entry_type is deprecated and will be removed in Home Assistant 2022.3.

Deprecated since Home Assistant 2021.12.

Logs a warning since Home Assistant 2021.12: _"Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue."_

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionalit)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`make black`)
- [ ] Tests have been added to verify that the new code works.
